### PR TITLE
fix: resolve integer overflow in validation maxFileSize constant

### DIFF
--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -124,7 +124,7 @@ func ValidateFileSize(size int64) error {
 	}
 
 	// Check against reasonable maximum file size (100GB)
-	const maxFileSize = 100 * 1024 * 1024 * 1024 // 100GB
+	const maxFileSize int64 = 100 * 1024 * 1024 * 1024 // 100GB
 	if size > maxFileSize {
 		return fmt.Errorf("file size %d bytes exceeds maximum allowed size of %d bytes", size, maxFileSize)
 	}


### PR DESCRIPTION
## Problem

GoReleaser was failing with the following error:


## Solution

- Changed  from untyped  to explicit  
- Prevents overflow on 32-bit systems while maintaining the same 100GB validation limit
- Fixes GoReleaser build process

## Testing

- [x] Unit tests pass: ok  	github.com/forest6511/gdl/pkg/validation	(cached)
- [x] No functional changes to validation logic
- [x] Same 100GB file size limit maintained

This is a simple type fix that should resolve the GoReleaser build issue.

Fixes the v1.0.0 release build process.