### PR TITLE
docs: update Homebrew installation to use full tap name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -180,9 +180,9 @@ scoops:
       owner: forest6511
       name: scoop-bucket
       token: "{{ .Env.SCOOP_GITHUB_TOKEN }}"
-  homepage: https://github.com/forest6511/gdl
-  description: Fast, concurrent file downloader for Go
-  license: MIT
+    homepage: https://github.com/forest6511/gdl
+    description: Fast, concurrent file downloader for Go
+    license: MIT
 
 # Disabled SBOM generation - requires syft to be installed
 # sboms:

--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ go install github.com/forest6511/gdl/cmd/gdl@latest
 #### Homebrew (macOS/Linux)
 ```bash
 brew tap forest6511/tap
-brew install gdl
+brew install forest6511/tap/gdl
 ```
+
+> **Note**: Use the full tap name `forest6511/tap/gdl` to avoid conflicts with the GNOME gdl package.
 
 #### Docker
 ```bash


### PR DESCRIPTION
## Summary

- Update Homebrew installation command to use  instead of gdl - A simple and efficient download tool

Usage: gdl [OPTIONS] URL
       gdl plugin <command> [args]

Download Options:
  -o, --output FILE        Output filename (default: extract from URL)
      --user-agent STRING  User-Agent string to use (default: gdl/gdl)
      --timeout DURATION   Download timeout (default: 30m)
  -f, --force             Overwrite existing files
      --create-dirs       Create parent directories if they don't exist
      --resume            Resume partial downloads if supported
  -q, --quiet             Quiet mode (no progress output)
  -v, --verbose           Verbose output
      --concurrent N      Number of concurrent connections (default: 4, max: 32)
      --chunk-size SIZE   Chunk size for concurrent downloads (default: auto)
                          Examples: 1MB, 512KB, 2GB
      --max-rate RATE     Maximum download rate (0 = unlimited)
                          Examples: 1MB/s, 500k, 2048
      --no-concurrent     Force single-threaded download
      --no-color          Disable colored output
      --interactive       Enable interactive prompts (default: auto-detect)
      --check-connectivity Check network connectivity before download
      --check-space       Check available disk space before download (default: true)
      --language LANG     Language for messages (en, ja, es, fr, default: en)
      --version           Show version information
  -h, --help              Show this help message

Plugin Options:
      --plugin NAME       Enable plugin for this download (can be used multiple times)
      --storage URL       Storage destination URL (s3://bucket/path/, gcs://bucket/path/)
      --plugin-dir DIR    Plugin directory (default: ~/.gdl/plugins)
      --plugin-config FILE Plugin configuration file (default: ~/.gdl/plugins.json)

Plugin Commands:
  plugin list             List all installed plugins
  plugin install <source> <name>  Install a plugin
  plugin remove <name>    Remove a plugin
  plugin enable <name>    Enable a plugin
  plugin disable <name>   Disable a plugin
  plugin config <name> --set <key>=<value>  Configure a plugin

Download Examples:
  dev https://example.com/file.zip                              # Basic download
  gdl --concurrent 8 https://example.com/largefile.iso         # Use 8 concurrent connections
  gdl --chunk-size 2MB https://example.com/file.zip            # Use 2MB chunks
  gdl --max-rate 1MB/s https://example.com/large-file.zip      # Limit to 1MB/s
  gdl --plugin oauth2 https://api.example.com/secure/file.zip  # Use OAuth2 plugin
  gdl --storage s3://mybucket/downloads/ https://example.com/file.zip  # Save to S3

Plugin Management Examples:
  gdl plugin list                                              # List installed plugins
  gdl plugin install github.com/user/gdl-plugin-s3 s3        # Install S3 plugin
  gdl plugin enable oauth2                                     # Enable OAuth2 plugin
  gdl plugin config oauth2 --set client_id=xxx                # Configure plugin
- Add note about naming conflict with GNOME gdl package in homebrew/core
- Ensures users can properly install our package without conflicts

This resolves the naming conflict discovered during Homebrew tap setup where users would get:


## Test plan
- [ ] Documentation review
- [ ] Installation command verification

🤖 Generated with [Claude Code](https://claude.ai/code)