### PR TITLE
fix(docker): add extra_files for go.mod and go.sum in GoReleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -152,6 +152,10 @@ dockers:
       - 'ghcr.io/forest6511/{{ .ProjectName }}:v{{ .Major }}.{{ .Minor }}'
       - 'ghcr.io/forest6511/{{ .ProjectName }}:latest'
     dockerfile: docker/Dockerfile
+    use: buildx
+    extra_files:
+      - go.mod
+      - go.sum
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"

--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ go install github.com/forest6511/gdl/cmd/gdl@latest
 #### Homebrew (macOS/Linux)
 ```bash
 brew tap forest6511/tap
-brew install gdl
+brew install forest6511/tap/gdl
 ```
+
+> **Note**: Use the full tap name `forest6511/tap/gdl` to avoid conflicts with the GNOME gdl package.
 
 #### Docker
 ```bash


### PR DESCRIPTION
## Summary

- Add  section to docker config in .goreleaser.yml
- Include go.mod and go.sum files explicitly for Docker build context
- Add  for better Docker build performance and consistency

## Problem Solved
Resolves the GoReleaser Docker build error:


## Changes Made
1. **Added extra_files section**: Explicitly includes go.mod and go.sum in Docker build context
2. **Added use: buildx**: Uses Docker buildx for better build performance and multi-platform support
3. **Maintains existing functionality**: All other Docker settings remain unchanged

## Test plan
- [ ] GoReleaser Docker build succeeds without file errors
- [ ] Cross-platform binaries are generated correctly
- [ ] Container images are pushed to GHCR successfully

🤖 Generated with [Claude Code](https://claude.ai/code)